### PR TITLE
Add os_build and arch_build settings

### DIFF
--- a/pmm/conan.cmake
+++ b/pmm/conan.cmake
@@ -331,6 +331,7 @@ endfunction()
 
 
 function(_pmm_conan_compute_arch_setting out sizeof_void_p)
+    # Todo: Allow architectures other than x86 and x86_64
     if(sizeof_void_p EQUAL 8)
         set(ret x86_64)
     else()
@@ -378,6 +379,11 @@ function(_pmm_conan_get_settings out)
         _pmm_log(DEBUG "Using os=${os}")
         list(APPEND ret os=${os})
     endif()
+    if(NOT ARG_SETTINGS MATCHES ";?os_build=")
+        _pmm_conan_compute_os_setting(os_build ${CMAKE_HOST_SYSTEM_NAME})
+        _pmm_log(DEBUG "Using os_build=${os_build}")
+        list(APPEND ret os_build=${os_build})
+    endif()
 
     _pmm_conan_compute_compiler_settings(comp_settings "${lang}" "${comp_id}" "${comp_version}")
     list(APPEND ret ${comp_settings})
@@ -392,11 +398,16 @@ function(_pmm_conan_get_settings out)
         list(APPEND ret build_type=${bt})
     endif()
 
-    # Todo: Cross compiling
     if(NOT ARG_SETTINGS MATCHES ";?arch=")
         _pmm_conan_compute_arch_setting(arch ${CMAKE_SIZEOF_VOID_P})
         _pmm_log(DEBUG "Using arch=${arch}")
         list(APPEND ret arch=${arch})
+    endif()
+    if(NOT ARG_SETTINGS MATCHES ";?arch_build=")
+        # Todo: Proper cross compiling support (don't assume host == target)
+        _pmm_conan_compute_arch_setting(arch_build ${CMAKE_SIZEOF_VOID_P})
+        _pmm_log(DEBUG "Using arch_build=${arch_build}")
+        list(APPEND ret arch_build=${arch_build})
     endif()
 
     if(NOT ARG_SETTINGS MATCHES ";?cppstd=")

--- a/pmm/conan.cmake
+++ b/pmm/conan.cmake
@@ -363,7 +363,8 @@ function(_pmm_conan_compute_arch_setting out arch_setting system_name system_pro
             RESULT_VARIABLE result
         )
         if(result)
-            _pmm_log(WARNING "Unable to obtain valid ${arch_setting} values from $ENV{CONAN_USER_HOME}/settings.yml. Assuming the ${arch_setting} supports every architecture type")
+            _pmm_log(WARNING "Unable to obtain valid ${arch_setting} values from $ENV{CONAN_USER_HOME}/settings.yml.")
+            set(valid_arch_settings)
         else()
             _pmm_log(DEBUG "Deterimned valid values of ${arch_setting} to be ${valid_arch_settings}")
         endif()

--- a/pmm/conan.settings.py
+++ b/pmm/conan.settings.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import yaml
+
+CONAN_USER_HOME = os.environ['CONAN_USER_HOME']
+CONAN_SETTING = sys.argv[1]
+
+with open(os.path.join(CONAN_USER_HOME, 'settings.yml'), 'r') as settings:
+    setting = yaml.load(settings)[CONAN_SETTING]
+    print(';'.join(setting))


### PR DESCRIPTION
Furthers #18 and partially addresses #15 (still broken for cross compilation across different architectures).

`arch_build` needs to be set differently than `arch`, but this is currently a difficult problem, as there's no `CMAKE_SIZEOF_VOID_P` for the host architecture. Furthermore, `arch` is currently only ever set to `x86` or `x86_64`, but those aren't the only possible architectures Conan supports. From the settings.yml, Conan seems to support all of:

- x86
- x86_64
- ppc32
- ppc64le
- ppc64
- armv4
- armv4i
- armv5el
- armv5hf
- armv6
- armv7
- armv7hf
- armv7s
- armv7k
- armv8
- armv8_32
- armv8.3
- sparc
- sparcv9
- mips
- mips64
- avr
- s390
- s390x
- asm.js
- wasm

If we truly want to support this, we need to map [`CMAKE_HOST_SYSTEM_PROCESSOR`] and [`CMAKE_SYSTEM_PROCESSOR`] to the right values, assuming they give the necessary information. Otherwise, we need some other way to obtain the information on what the architecture is.

  [`CMAKE_HOST_SYSTEM_PROCESSOR`]: https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_PROCESSOR.html
  [`CMAKE_SYSTEM_PROCESSOR`]: https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_PROCESSOR.html