### PR TITLE
FIX: vcpkg install sometimes requires '--recursive'

### DIFF
--- a/pmm/vcpkg.cmake
+++ b/pmm/vcpkg.cmake
@@ -208,6 +208,7 @@ function(_pmm_vcpkg)
                 CC=${CMAKE_C_COMPILER}
                 CXX=${CMAKE_CXX_COMPILER}
             "${PMM_VCPKG_EXECUTABLE}" install
+	        --recurse
                 --triplet "${ARG_TRIPLET}"
                 ${ARG_REQUIRES}
             )


### PR DESCRIPTION
Sometimes, `vcpkg install' needs '--recursive', or errors like below:

```
/home/centos/opt/clion-2021.1.1/bin/cmake/linux/bin/cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G "CodeBlocks - Unix Makefiles" /home/centos/CLionProjects/cpp1
-- [pmm] [verbose] Using vcpkg target triplet x64-linux
-- [pmm] [debug  ] vcpkg directory is /home/centos/.local/share/pmm/1.5.1/vcpkg-2021.05.12
-- [pmm] [debug  ] Expecting vcpkg executable at /home/centos/.local/share/pmm/1.5.1/vcpkg-2021.05.12/vcpkg
-- [pmm] Installing requirements with vcpkg
-- [pmm] [debug  ] Executing command: /home/centos/opt/clion-2021.1.1/bin/cmake/linux/bin/cmake -E env VCPKG_ROOT=/home/centos/.local/share/pmm/1.5.1/vcpkg-2021.05.12 CC=/usr/bin/clang CXX=/usr/bin/clang++ /home/centos/.local/share/pmm/1.5.1/vcpkg-2021.05.12/vcpkg install --triplet x64-linux uwebsockets hiredis zlib uSockets[ssl,event] NO_EAT_OUTPUT 
Computing installation plan...
The following packages are already installed:
    hiredis[core]:x64-linux -> 1.0.0#1
    zlib[core]:x64-linux -> 1.2.11#10
The following packages will be rebuilt:
    usockets[core,event,ssl]:x64-linux -> 0.7.1
    uwebsockets[core]:x64-linux -> 19.0.0.5
The following packages will be built and installed:
  * openssl[core]:x64-linux -> 1.1.1k#1
Additional packages (*) will be modified to complete this operation.
If you are sure you want to rebuild the above packages, run the command with the --recurse option
CMake Error at cmake-build-debug/_pmm/1.5.1/vcpkg.cmake:216 (message):
  Failed to install requirements with vcpkg [1]:

Call Stack (most recent call first):
  cmake-build-debug/_pmm/1.5.1/main.cmake:38 (_pmm_vcpkg)
  cmake-build-debug/_pmm/1.5.1/main.cmake:52 (_pmm_project_fn)
  CMakeLists.txt:9 (pmm)


-- Configuring incomplete, errors occurred!
See also "/home/centos/CLionProjects/cpp1/cmake-build-debug/CMakeFiles/CMakeOutput.log".

[Finished]

```